### PR TITLE
Create frontend-backend prototype for futures command center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.DS_Store
+dist
+.vscode
+.env
+backend/.env
+frontend/node_modules
+backend/node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# topstepwebsite
-site
+# TopstepX Command Center
+
+A futures-only command center prototype featuring a modern React frontend, an Express backend broker, and a data service layer that wraps the TopstepX Gateway API with offline mocks. The stack is designed for iterative development toward a self-directed quant trading assistant.
+
+## Architecture Overview
+
+```
+.
+├── backend/        # Express API + WebSocket broker + context store
+├── frontend/       # Vite + React (TypeScript) interface
+└── docs/           # Quant bot interface specification
+```
+
+### Data Flow
+1. **Frontend** requests `/api/markets/snapshot` for initial quotes and opens a WebSocket to `/api/markets/stream` for live updates.
+2. **Backend** proxies to the TopstepX Gateway via `TopstepGatewayService`. In mock mode it emits deterministic synthetic futures data for ES=F, NQ=F, YM=F, RTY=F, CL=F, GC=F, and ZN=F.
+3. **Context Store** records user risk preferences and decision logs, enabling downstream quant modules to reference the latest state.
+4. **Quant Bot (future)** will call the documented interface in `docs/quant-bot-interface.md` to request buy signals targeting a 55–61% hit rate.
+
+## Prerequisites
+- Node.js 18+
+- npm or pnpm/yarn
+
+## Setup
+
+### 1. Install dependencies
+```bash
+cd backend
+npm install
+cd ../frontend
+npm install
+```
+
+### 2. Environment configuration
+Create `backend/.env` (optional) and set:
+```
+TOPSTEP_GATEWAY_URL=https://api.topstepx.io
+TOPSTEP_GATEWAY_KEY=<your_topstepx_api_key>
+USE_LIVE_GATEWAY=true # omit or set to false to stay in mock mode
+PORT=4000
+```
+
+The frontend uses Vite defaults and proxies `/api` to `http://localhost:4000` during development.
+
+### 3. Run backend
+```bash
+cd backend
+npm run dev
+```
+
+### 4. Run frontend
+```bash
+cd frontend
+npm run dev
+```
+Visit `http://localhost:5173` to view the Command Center UI.
+
+## Risk Controls & User Context
+- `ContextStore` tracks per-user risk budget, daily draw limits, and execution decisions.
+- Use `POST /api/markets/context` to upsert risk parameters and `POST /api/markets/decision` to log trade outcomes.
+- Guardrails should be enforced before forwarding quant bot signals to execution venues.
+
+## Available API Endpoints
+- `GET /health` – service heartbeat, indicates mock vs live mode.
+- `GET /api/markets/symbols` – allowed futures symbols.
+- `POST /api/markets/snapshot` – returns latest quotes for requested symbols.
+- `POST /api/markets/context` – stores or updates a user context payload.
+- `POST /api/markets/decision` – appends a trade decision to the user log.
+- `WS /api/markets/stream` – JSON quotes pushed as `{ symbol, last, change, changePct, high, low, volume, timestamp }`.
+
+## Offline Development
+- By default the backend runs in mock mode (no external API calls) generating deterministic price action per symbol.
+- To exercise snapshot + stream without internet access, keep `USE_LIVE_GATEWAY` unset.
+
+## Quant Bot Roadmap
+- Specification lives in [`docs/quant-bot-interface.md`](docs/quant-bot-interface.md).
+- Emphasizes deterministic backtests, telemetry logging, and signal confidence bands.
+
+## Testing & Linting
+- Run `npm run build` in `frontend` to type-check and bundle.
+- Backend tests are not yet implemented; add integration tests around `ContextStore` and WebSocket flow as future work.
+
+## Operational Notes
+- Harden authentication before production use. Current implementation assumes a trusted environment.
+- Always validate strategy hit rate remains within 55–61% band. Consider automated alerts when breaching.
+- Extend `ContextStore` with persistent storage (Redis/Postgres) before scaling beyond prototype.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "topstep-backend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "ws": "^8.16.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/routes/marketRoutes.js
+++ b/backend/src/routes/marketRoutes.js
@@ -1,0 +1,39 @@
+import express from 'express';
+import { TopstepGatewayService } from '../services/topstepGateway.js';
+
+export function createMarketRouter({ gateway, contextStore }) {
+  const router = express.Router();
+  const service = gateway ?? new TopstepGatewayService({ useMocks: true });
+
+  router.get('/symbols', (_req, res) => {
+    res.json({ symbols: service.listFuturesSymbols() });
+  });
+
+  router.post('/snapshot', async (req, res, next) => {
+    try {
+      const { symbols } = req.body;
+      const snapshot = await service.fetchSnapshot(symbols);
+      res.json(snapshot);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/context', (req, res) => {
+    const { userId = 'demo-user', profile } = req.body;
+    const nextProfile = contextStore.upsertSession(userId, profile ?? {});
+    res.json(nextProfile);
+  });
+
+  router.post('/decision', (req, res, next) => {
+    try {
+      const { userId = 'demo-user', decision } = req.body;
+      const session = contextStore.appendDecision(userId, decision);
+      res.json(session);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,71 @@
+import http from 'http';
+import express from 'express';
+import cors from 'cors';
+import { WebSocketServer } from 'ws';
+import { createMarketRouter } from './routes/marketRoutes.js';
+import { TopstepGatewayService } from './services/topstepGateway.js';
+import { ContextStore } from './utils/contextStore.js';
+
+const PORT = process.env.PORT ?? 4000;
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const gateway = new TopstepGatewayService({
+  baseUrl: process.env.TOPSTEP_GATEWAY_URL,
+  apiKey: process.env.TOPSTEP_GATEWAY_KEY,
+  useMocks: process.env.USE_LIVE_GATEWAY !== 'true'
+});
+const contextStore = new ContextStore();
+
+app.use('/api/markets', createMarketRouter({ gateway, contextStore }));
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', mode: gateway.useMocks ? 'mock' : 'live' });
+});
+
+app.use((err, _req, res, _next) => {
+  console.error('backend error', err);
+  res.status(500).json({ error: 'Internal Server Error', detail: err.message });
+});
+
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server, path: '/api/markets/stream' });
+
+wss.on('connection', (socket) => {
+  let stream;
+
+  socket.on('message', (message) => {
+    try {
+      const payload = JSON.parse(message.toString());
+      if (payload.type === 'subscribe') {
+        if (stream) {
+          stream.stop?.();
+          gateway.stopStream(stream);
+        }
+        stream = gateway.createStream(payload.symbols);
+        stream.on('quote', (quote) => {
+          if (socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify(quote));
+          }
+        });
+        stream.start?.();
+      }
+    } catch (error) {
+      socket.send(JSON.stringify({ type: 'error', message: error.message }));
+    }
+  });
+
+  socket.on('close', () => {
+    if (stream) {
+      stream.stop?.();
+      gateway.stopStream(stream);
+      stream = undefined;
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Topstep backend listening on port ${PORT}`);
+});

--- a/backend/src/services/mockData.js
+++ b/backend/src/services/mockData.js
@@ -1,0 +1,63 @@
+import { EventEmitter } from 'events';
+
+export const FUTURES_SYMBOLS = ['ES=F', 'NQ=F', 'YM=F', 'RTY=F', 'CL=F', 'GC=F', 'ZN=F'];
+
+function basePriceFor(symbol) {
+  const seeds = {
+    'ES=F': 5200,
+    'NQ=F': 18200,
+    'YM=F': 39000,
+    'RTY=F': 2050,
+    'CL=F': 78,
+    'GC=F': 2425,
+    'ZN=F': 111
+  };
+  return seeds[symbol] ?? 100;
+}
+
+function seededDrift(symbol, tick) {
+  const factor = symbol.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return Math.sin(tick / 180 + factor) * 0.6;
+}
+
+export function createMockQuote(symbol, tick = Date.now()) {
+  const baseline = basePriceFor(symbol);
+  const drift = seededDrift(symbol, tick);
+  const last = baseline + drift;
+  return {
+    symbol,
+    last,
+    change: drift,
+    changePct: (drift / baseline) * 100,
+    high: baseline + Math.abs(drift) * 1.2,
+    low: baseline - Math.abs(drift) * 1.1,
+    volume: Math.floor(10_000 + (Math.abs(drift) * 8_000) % 9_000),
+    timestamp: new Date(tick).toISOString()
+  };
+}
+
+export class MockMarketStream extends EventEmitter {
+  constructor(symbols, intervalMs = 2_000) {
+    super();
+    this.symbols = symbols;
+    this.intervalMs = intervalMs;
+    this.timer = null;
+  }
+
+  start() {
+    this.stop();
+    this.timer = setInterval(() => {
+      const tick = Date.now();
+      this.symbols.forEach((symbol) => {
+        this.emit('quote', createMockQuote(symbol, tick));
+      });
+    }, this.intervalMs);
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/backend/src/services/topstepGateway.js
+++ b/backend/src/services/topstepGateway.js
@@ -1,0 +1,82 @@
+import { MockMarketStream, createMockQuote, FUTURES_SYMBOLS } from './mockData.js';
+
+const DEFAULT_BASE_URL = 'https://api.topstepx.io';
+
+export class TopstepGatewayService {
+  constructor({ baseUrl = DEFAULT_BASE_URL, apiKey = '', useMocks = false } = {}) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.useMocks = useMocks;
+    this.mockStreams = new Map();
+  }
+
+  listFuturesSymbols() {
+    return [...FUTURES_SYMBOLS];
+  }
+
+  async fetchQuote(symbol) {
+    if (!FUTURES_SYMBOLS.includes(symbol)) {
+      throw new Error(`Unsupported symbol: ${symbol}`);
+    }
+
+    if (this.useMocks) {
+      return createMockQuote(symbol);
+    }
+
+    const response = await fetch(`${this.baseUrl}/markets/quote?symbol=${encodeURIComponent(symbol)}`, {
+      headers: this.#headers()
+    });
+
+    if (!response.ok) {
+      throw new Error(`Gateway error ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async fetchSnapshot(symbols = FUTURES_SYMBOLS) {
+    const uniqueSymbols = [...new Set(symbols.filter((sym) => FUTURES_SYMBOLS.includes(sym)))];
+    if (this.useMocks) {
+      const quotes = Object.fromEntries(uniqueSymbols.map((symbol) => [symbol, createMockQuote(symbol)]));
+      return { quotes };
+    }
+
+    const response = await fetch(`${this.baseUrl}/markets/snapshot`, {
+      method: 'POST',
+      headers: { ...this.#headers(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ symbols: uniqueSymbols })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Gateway error ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  createStream(symbols = FUTURES_SYMBOLS) {
+    const filtered = symbols.filter((symbol) => FUTURES_SYMBOLS.includes(symbol));
+    if (this.useMocks) {
+      const mock = new MockMarketStream(filtered);
+      this.mockStreams.set(mock, mock);
+      return mock;
+    }
+
+    throw new Error('Real-time gateway streaming requires WebSocket integration not available offline.');
+  }
+
+  stopStream(stream) {
+    if (stream && this.mockStreams.has(stream)) {
+      stream.stop();
+      this.mockStreams.delete(stream);
+    }
+  }
+
+  #headers() {
+    const headers = {};
+    if (this.apiKey) {
+      headers['x-api-key'] = this.apiKey;
+    }
+    return headers;
+  }
+}

--- a/backend/src/utils/contextStore.js
+++ b/backend/src/utils/contextStore.js
@@ -1,0 +1,37 @@
+export class ContextStore {
+  constructor() {
+    this.sessions = new Map();
+  }
+
+  upsertSession(userId, payload) {
+    const baseline = this.sessions.get(userId) ?? {
+      userId,
+      riskProfile: { maxDraw: 1500, dailyGoal: 800 },
+      lastDecisions: []
+    };
+    const merged = {
+      ...baseline,
+      ...payload,
+      lastUpdated: new Date().toISOString()
+    };
+    this.sessions.set(userId, merged);
+    return merged;
+  }
+
+  appendDecision(userId, decision) {
+    const session = this.sessions.get(userId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+    const next = {
+      ...session,
+      lastDecisions: [...session.lastDecisions.slice(-20), { ...decision, timestamp: new Date().toISOString() }]
+    };
+    this.sessions.set(userId, next);
+    return next;
+  }
+
+  getSession(userId) {
+    return this.sessions.get(userId) ?? null;
+  }
+}

--- a/docs/quant-bot-interface.md
+++ b/docs/quant-bot-interface.md
@@ -1,0 +1,84 @@
+# Quant Trading Bot Interface (Design Draft)
+
+## Objectives
+- Deliver futures-only trade recommendations with a targeted hit rate of **55–61%**.
+- Provide auditable backtesting hooks and live performance telemetry.
+- Integrate with the TopstepX Gateway data service for consistent market context.
+
+## Module Overview
+```
+QuantBotService
+├── configure(params: QuantBotConfig)
+├── requestSignals(request: SignalRequest): Promise<SignalBatch>
+├── registerBacktestRun(params: BacktestConfig): AsyncIterable<BacktestResult>
+└── logPerformance(event: PerformanceEvent): void
+```
+
+### Types
+- `QuantBotConfig`
+  - `strategyId: string` – unique identifier for the algorithm.
+  - `riskModel: 'conservative' | 'balanced' | 'aggressive'` – toggles guardrails.
+  - `maxConcurrentPositions: number` – trade concurrency cap.
+  - `instruments: InstrumentSymbol[]` – allowed futures symbols.
+  - `hitRateTarget: [0.55, 0.61]` – enforced target band.
+  - `slippageBps: number` – assumed slippage.
+  - `dataFeed: DataFeedHandle` – handle produced by the data service layer.
+
+- `SignalRequest`
+  - `userId: string`
+  - `timeframe: '1m' | '5m' | '15m' | '1h'`
+  - `contextId: string` – references the ContextStore snapshot.
+  - `riskOverrides?: Partial<RiskParameters>`
+
+- `SignalBatch`
+  - `generatedAt: string`
+  - `signals: TradeSignal[]`
+  - `confidence: number` – aggregated probability of success.
+  - `hitRateWindow: PerformanceWindow` – trailing stats for 20, 50, 100 trade windows.
+
+- `TradeSignal`
+  - `symbol: InstrumentSymbol`
+  - `direction: 'long' | 'short'`
+  - `entry: number`
+  - `stop: number`
+  - `target: number`
+  - `confidence: number`
+  - `timeInForce: 'DAY' | 'GTC'`
+  - `rMultiple: number`
+
+- `BacktestConfig`
+  - `symbol: InstrumentSymbol`
+  - `start: string`
+  - `end: string`
+  - `timeframe: string`
+  - `parameters: Record<string, number | string>`
+
+- `BacktestResult`
+  - `timestamp: string`
+  - `equityCurve: number`
+  - `drawdown: number`
+  - `hitRate: number`
+  - `trades: number`
+
+- `PerformanceEvent`
+  - `userId: string`
+  - `contextId: string`
+  - `signalId: string`
+  - `outcome: 'win' | 'loss' | 'breakeven'`
+  - `rMultiple: number`
+  - `latencyMs: number`
+
+## Backtesting Hooks
+- **Streaming backtests:** `registerBacktestRun` yields incremental equity snapshots to support UI timelines.
+- **Data alignment:** uses the same `DataFeedHandle` as live mode to ensure indicator parity.
+- **Reproducibility:** every backtest run logs a deterministic seed and configuration hash.
+
+## Performance Logging
+- Append `PerformanceEvent` instances to the ContextStore `lastDecisions` queue.
+- Persist aggregated hit rate metrics across rolling windows (20/50/100 trades).
+- Emit structured logs to `logs/performance.log` (future work) with JSON lines for downstream analytics.
+
+## Integration Notes
+- Signals consumed by the frontend should include a `confidence` metric and `hitRateWindow` band to visually indicate adherence to the 55–61% goal.
+- Risk controls must reject signals that violate user-specific `riskBudget` or `dailyDrawLimit` from the ContextStore profile.
+- Future iterations may introduce reinforcement learning loops; ensure interfaces remain stateless between calls aside from explicit `configure` and logging methods.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TopstepX Command Center</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "topstep-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^11.0.0",
+    "zustand": "^4.5.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.49",
+    "@types/react-dom": "^18.2.17",
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useMarketStream } from './hooks/useMarketStream';
+import { InstrumentCard } from './components/InstrumentCard';
+import { ActionPanel } from './components/ActionPanel';
+import { Timeline } from './components/Timeline';
+import { useUserProfile } from './hooks/useUserProfile';
+import './styles/layout.css';
+
+const heroGradient = {
+  background:
+    'radial-gradient(120% 120% at 90% 10%, rgba(76, 0, 255, 0.8) 0%, rgba(15, 12, 41, 0.9) 40%, rgba(36, 36, 62, 0.95) 70%, rgba(10, 10, 15, 1) 100%)'
+};
+
+const instruments = ['ES=F', 'NQ=F', 'YM=F', 'RTY=F', 'CL=F', 'GC=F', 'ZN=F'] as const;
+
+function App() {
+  const { quotes, status } = useMarketStream(instruments);
+  const profile = useUserProfile();
+
+  const sortedQuotes = useMemo(
+    () =>
+      instruments
+        .map((symbol) => quotes[symbol])
+        .filter(Boolean)
+        .sort((a, b) => a.symbol.localeCompare(b.symbol)),
+    [quotes]
+  );
+
+  return (
+    <div className="app-root">
+      <header className="hero" style={heroGradient}>
+        <div className="hero__content">
+          <p className="eyebrow">TopstepX Gateway</p>
+          <h1>Command your edge in the futures arena.</h1>
+          <p className="lede">
+            Fuse real-time market intelligence with disciplined risk overlays. Elevate your trading by
+            tracking curated TopstepX futures streams and launching playbooks with surgical precision.
+          </p>
+          <div className="cta-group">
+            <a className="cta cta--primary" href="#launch">
+              Launch Trading Desk
+            </a>
+            <a className="cta cta--ghost" href="#learn">
+              Review Playbooks
+            </a>
+          </div>
+        </div>
+        <AnimatePresence>
+          <motion.div
+            className="hero__orb"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 1.2, ease: 'easeOut' }}
+          />
+        </AnimatePresence>
+      </header>
+
+      <main>
+        <section id="launch" className="dashboard">
+          <div className="dashboard__left">
+            <div className="panel">
+              <div className="panel__header">
+                <h2>Futures Pulse</h2>
+                <span className={`status status--${status}`}>{status.toUpperCase()}</span>
+              </div>
+              <div className="panel__grid">
+                {sortedQuotes.map((quote) => (
+                  <InstrumentCard key={quote.symbol} quote={quote} />
+                ))}
+              </div>
+            </div>
+
+            <Timeline entries={profile.timeline} />
+          </div>
+          <ActionPanel profile={profile} />
+        </section>
+
+        <section id="learn" className="playbooks">
+          <div className="playbooks__card">
+            <h3>Risk Canvas</h3>
+            <p>
+              Set guardrails before you launch. Configure product limits, daily draw, and performance drift
+              controls tied to your evaluation plan.
+            </p>
+          </div>
+          <div className="playbooks__card">
+            <h3>Signal Intelligence</h3>
+            <p>
+              Deploy the quant bot API to scout setups targeting a 55–61% hit rate. Backtesting hooks and
+              telemetry keep the model honest.
+            </p>
+          </div>
+          <div className="playbooks__card">
+            <h3>Execution Modes</h3>
+            <p>
+              Simulate, shadow, or go live. Each mode routes through the broker gateway while logging every
+              decision for compliance review.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <p>© {new Date().getFullYear()} TopstepX Experimental Command Center</p>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/ActionPanel.tsx
+++ b/frontend/src/components/ActionPanel.tsx
@@ -1,0 +1,44 @@
+import { motion } from 'framer-motion';
+import type { UserProfile } from '../services/marketTypes';
+
+interface ActionPanelProps {
+  profile: UserProfile;
+}
+
+export function ActionPanel({ profile }: ActionPanelProps) {
+  return (
+    <aside className="action-panel">
+      <motion.div className="action-panel__card" layout transition={{ duration: 0.4 }}>
+        <h2>{profile.name}'s Playbook</h2>
+        <p className="action-panel__subtitle">{profile.role}</p>
+        <div className="action-panel__stats">
+          <div>
+            <span className="label">Risk Budget</span>
+            <span className="value">{profile.riskBudget}%</span>
+          </div>
+          <div>
+            <span className="label">Daily Draw</span>
+            <span className="value">${profile.dailyDrawLimit.toLocaleString()}</span>
+          </div>
+          <div>
+            <span className="label">Hit Rate Target</span>
+            <span className="value">55–61%</span>
+          </div>
+        </div>
+        <button className="cta cta--primary">Deploy Quant Recon</button>
+        <button className="cta cta--ghost">Queue Risk Check</button>
+      </motion.div>
+      <div className="action-panel__log">
+        <h3>Live Notes</h3>
+        <ul>
+          {profile.notes.map((note) => (
+            <li key={note.timestamp}>
+              <span className="timestamp">{note.timestamp}</span>
+              <span>{note.message}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/InstrumentCard.tsx
+++ b/frontend/src/components/InstrumentCard.tsx
@@ -1,0 +1,43 @@
+import { motion } from 'framer-motion';
+import type { MarketQuote } from '../services/marketTypes';
+
+interface InstrumentCardProps {
+  quote: MarketQuote;
+}
+
+export function InstrumentCard({ quote }: InstrumentCardProps) {
+  const { symbol, last, change, changePct, high, low, volume } = quote;
+  const isUp = change >= 0;
+
+  return (
+    <motion.article
+      className={`instrument-card ${isUp ? 'instrument-card--up' : 'instrument-card--down'}`}
+      layout
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+    >
+      <header>
+        <h3>{symbol}</h3>
+        <span className="instrument-card__price">{last.toFixed(2)}</span>
+      </header>
+      <p className="instrument-card__change">
+        {isUp ? '▲' : '▼'} {change.toFixed(2)} ({changePct.toFixed(2)}%)
+      </p>
+      <dl className="instrument-card__meta">
+        <div>
+          <dt>High</dt>
+          <dd>{high.toFixed(2)}</dd>
+        </div>
+        <div>
+          <dt>Low</dt>
+          <dd>{low.toFixed(2)}</dd>
+        </div>
+        <div>
+          <dt>Volume</dt>
+          <dd>{volume.toLocaleString()}</dd>
+        </div>
+      </dl>
+    </motion.article>
+  );
+}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,0 +1,24 @@
+import type { TimelineEntry } from '../services/marketTypes';
+
+interface TimelineProps {
+  entries: TimelineEntry[];
+}
+
+export function Timeline({ entries }: TimelineProps) {
+  return (
+    <div className="timeline">
+      <h2>Execution Timeline</h2>
+      <ol>
+        {entries.map((entry) => (
+          <li key={entry.timestamp}>
+            <span className="timestamp">{entry.timestamp}</span>
+            <div>
+              <p className="title">{entry.title}</p>
+              <p className="description">{entry.description}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useMarketStream.ts
+++ b/frontend/src/hooks/useMarketStream.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MarketQuote, MarketSnapshot, InstrumentSymbol } from '../services/marketTypes';
+
+interface MarketStreamState {
+  quotes: Record<string, MarketQuote>;
+  status: 'idle' | 'syncing' | 'live' | 'offline';
+}
+
+export function useMarketStream(symbols: readonly InstrumentSymbol[]) {
+  const [state, setState] = useState<MarketStreamState>({ quotes: {}, status: 'idle' });
+  const retryRef = useRef<number>();
+
+  useEffect(() => {
+    let cancelled = false;
+    let ws: WebSocket | null = null;
+
+    async function bootstrap() {
+      setState((prev) => ({ ...prev, status: 'syncing' }));
+      try {
+        const response = await fetch('/api/markets/snapshot', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ symbols })
+        });
+        const snapshot: MarketSnapshot = await response.json();
+        if (cancelled) return;
+        setState({ quotes: snapshot.quotes, status: 'live' });
+      } catch (error) {
+        console.error('snapshot failed', error);
+        setState((prev) => ({ ...prev, status: 'offline' }));
+      }
+    }
+
+    function connectSocket() {
+      const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      try {
+        ws = new WebSocket(`${protocol}://${window.location.host}/api/markets/stream`);
+        ws.onopen = () => {
+          ws?.send(JSON.stringify({ type: 'subscribe', symbols }));
+        };
+        ws.onmessage = (event) => {
+          const payload = JSON.parse(event.data) as MarketQuote;
+          setState((prev) => ({
+            quotes: { ...prev.quotes, [payload.symbol]: payload },
+            status: 'live'
+          }));
+        };
+        ws.onclose = () => {
+          setState((prev) => ({ ...prev, status: 'offline' }));
+          retryRef.current = window.setTimeout(connectSocket, 5_000);
+        };
+        ws.onerror = () => {
+          ws?.close();
+        };
+      } catch (error) {
+        console.error('socket error', error);
+      }
+    }
+
+    bootstrap().then(connectSocket);
+
+    return () => {
+      cancelled = true;
+      if (retryRef.current) window.clearTimeout(retryRef.current);
+      ws?.close();
+    };
+  }, [symbols]);
+
+  return state;
+}

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import type { UserProfile } from '../services/marketTypes';
+
+const baseProfile: UserProfile = {
+  name: 'Avery Quinn',
+  role: 'Futures Strategist',
+  riskBudget: 35,
+  dailyDrawLimit: 1500,
+  notes: [
+    { timestamp: '07:45', message: 'Bias long ES until NY open if VWAP holds.' },
+    { timestamp: '08:10', message: 'GC rotation underway, tighten stops to 3.2.' }
+  ],
+  timeline: [
+    {
+      timestamp: '07:00',
+      title: 'Premarket Scan',
+      description: 'Vol compression overnight, watch RTY for expansion above 2030.'
+    },
+    {
+      timestamp: '08:30',
+      title: 'Data Drop',
+      description: 'CPI inline, CL bid emerges. Quant bot flagged mean reversion long.'
+    }
+  ]
+};
+
+export function useUserProfile() {
+  return useMemo(() => baseProfile, []);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/services/marketTypes.ts
+++ b/frontend/src/services/marketTypes.ts
@@ -1,0 +1,36 @@
+export type InstrumentSymbol = 'ES=F' | 'NQ=F' | 'YM=F' | 'RTY=F' | 'CL=F' | 'GC=F' | 'ZN=F';
+
+export interface MarketQuote {
+  symbol: InstrumentSymbol;
+  last: number;
+  change: number;
+  changePct: number;
+  high: number;
+  low: number;
+  volume: number;
+  timestamp: string;
+}
+
+export interface MarketSnapshot {
+  quotes: Record<InstrumentSymbol, MarketQuote>;
+}
+
+export interface TimelineEntry {
+  timestamp: string;
+  title: string;
+  description: string;
+}
+
+export interface UserNote {
+  timestamp: string;
+  message: string;
+}
+
+export interface UserProfile {
+  name: string;
+  role: string;
+  riskBudget: number;
+  dailyDrawLimit: number;
+  notes: UserNote[];
+  timeline: TimelineEntry[];
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,30 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #060608;
+  color: #f8f8fb;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, rgba(100, 67, 255, 0.2), transparent 40%),
+    linear-gradient(180deg, #0f0c29 0%, #302b63 45%, #24243e 100%);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -1,0 +1,287 @@
+.app-root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  gap: 4rem;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 6rem clamp(2rem, 6vw, 6rem);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.hero__content {
+  max-width: 720px;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.eyebrow {
+  letter-spacing: 0.4rem;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.lede {
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.cta-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.cta {
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid transparent;
+}
+
+.cta--primary {
+  background: linear-gradient(120deg, #a855f7 0%, #6366f1 100%);
+  box-shadow: 0 0.6rem 1.5rem rgba(99, 102, 241, 0.4);
+}
+
+.cta--ghost {
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.cta:hover {
+  transform: translateY(-2px);
+}
+
+.hero__orb {
+  position: absolute;
+  inset: -30% 45% auto auto;
+  width: clamp(20rem, 40vw, 32rem);
+  aspect-ratio: 1;
+  background: radial-gradient(circle at 30% 30%, rgba(167, 139, 250, 0.8), transparent 65%),
+    radial-gradient(circle at 70% 70%, rgba(56, 189, 248, 0.4), transparent 55%);
+  filter: blur(0px);
+  opacity: 0.8;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  gap: 6rem;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(260px, 1.2fr);
+  gap: 2rem;
+  padding: 0 clamp(2rem, 6vw, 6rem);
+}
+
+.panel {
+  background: rgba(14, 16, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 20px 60px rgba(14, 16, 40, 0.55);
+  backdrop-filter: blur(24px);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 2rem;
+}
+
+.panel__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.status {
+  font-size: 0.75rem;
+  letter-spacing: 0.2rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.status--live {
+  border-color: rgba(56, 189, 248, 0.6);
+  color: rgba(56, 189, 248, 0.9);
+}
+
+.status--offline {
+  border-color: rgba(248, 113, 113, 0.6);
+  color: rgba(248, 113, 113, 0.9);
+}
+
+.status--syncing {
+  border-color: rgba(244, 114, 182, 0.6);
+  color: rgba(244, 114, 182, 0.9);
+}
+
+.instrument-card {
+  padding: 1.4rem;
+  border-radius: 18px;
+  background: rgba(19, 23, 48, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.8rem;
+  transition: transform 0.3s ease;
+}
+
+.instrument-card:hover {
+  transform: translateY(-4px);
+}
+
+.instrument-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.instrument-card__price {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.instrument-card__change {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.instrument-card__meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.instrument-card--up {
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.instrument-card--down {
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.action-panel {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.action-panel__card {
+  background: linear-gradient(140deg, rgba(56, 189, 248, 0.3), rgba(88, 28, 135, 0.3));
+  border-radius: 24px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.action-panel__subtitle {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.action-panel__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.action-panel__stats .label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.action-panel__stats .value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.action-panel__log {
+  background: rgba(17, 20, 40, 0.9);
+  border-radius: 20px;
+  padding: 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.action-panel__log ul {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.timeline {
+  margin-top: 2rem;
+  background: rgba(12, 16, 38, 0.9);
+  border-radius: 24px;
+  padding: 1.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.timeline ol {
+  list-style: none;
+  display: grid;
+  gap: 1.4rem;
+}
+
+.timeline .title {
+  font-weight: 600;
+}
+
+.timeline .description {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.playbooks {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  padding: 0 clamp(2rem, 6vw, 6rem) 6rem;
+}
+
+.playbooks__card {
+  padding: 1.8rem;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(14, 14, 32, 0.85);
+  box-shadow: 0 20px 40px rgba(6, 6, 8, 0.4);
+  display: grid;
+  gap: 0.8rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+@media (max-width: 960px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .action-panel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0',
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- build a Vite + React futures command center UI with clear calls to action and postmodern styling
- add an Express backend with mockable TopstepX Gateway data service, WebSocket broker, and user context store
- document the quant bot interface plus end-to-end setup, data flow, and risk control guidelines

## Testing
- not run (dependency installation requires external registry access)

------
https://chatgpt.com/codex/tasks/task_e_68e1dd7564988329a5fa569d0fbfad78