### PR TITLE
Check npm availability before launching services

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,6 @@ Visit `http://localhost:5173` to view the Command Center UI.
 - Harden authentication before production use. Current implementation assumes a trusted environment.
 - Always validate strategy hit rate remains within 55–61% band. Consider automated alerts when breaching.
 - Extend `ContextStore` with persistent storage (Redis/Postgres) before scaling beyond prototype.
+
+### Troubleshooting
+- If the launcher exits with `Unable to locate the npm executable`, install Node.js/npm and ensure `npm` (or `npm.cmd` on Windows) is in your `PATH` before running `python main.py`.


### PR DESCRIPTION
## Summary
- ensure the launcher resolves the npm executable (including npm.cmd on Windows) before starting services
- surface a clear RuntimeError when npm is missing and update the README with recovery steps

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e0f3ac74832992d6f197179907f1