### PR TITLE
feat: stratify Codus epochs by decade memory

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,108 +1,513 @@
-import { useMemo } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useMarketStream } from './hooks/useMarketStream';
-import { InstrumentCard } from './components/InstrumentCard';
-import { ActionPanel } from './components/ActionPanel';
-import { Timeline } from './components/Timeline';
-import { useUserProfile } from './hooks/useUserProfile';
+import type { CSSProperties } from 'react';
+import { useMemo, useState } from 'react';
 import './styles/layout.css';
 
-const heroGradient = {
-  background:
-    'radial-gradient(120% 120% at 90% 10%, rgba(76, 0, 255, 0.8) 0%, rgba(15, 12, 41, 0.9) 40%, rgba(36, 36, 62, 0.95) 70%, rgba(10, 10, 15, 1) 100%)'
+type Phase = 'proto' | 'ascension' | 'overclock' | 'decay';
+
+type EpochRecord = {
+  year: number;
+  phase: Phase;
+  motif: string;
+  decade: number;
+  eraTitle: string;
+  logline: string;
+  upgrade: string;
+  regret: string;
+  artifact: string;
+  mythoPatch: string;
+  devNote: string;
+  valueDrift: string;
+  abandoned: string;
+  echo: string;
+  memory: string;
+  status: string;
+  glitch: string;
+  devGod?: string;
+  decay: number;
 };
 
-const instruments = ['ES=F', 'NQ=F', 'YM=F', 'RTY=F', 'CL=F', 'GC=F', 'ZN=F'] as const;
+type PerceptionMode = {
+  id: string;
+  name: string;
+  description: string;
+  highlight: (epoch: EpochRecord) => boolean;
+};
+
+const motifs = [
+  'amber-grid',
+  'cobalt-lattice',
+  'echo-slab',
+  'ritual-terminal',
+  'spiral ledger',
+  'silent ticker',
+  'contrarian kiosk',
+  'mycelial loom',
+  'glacial marquee',
+  'ashen observatory',
+  'ultraviolet causeway',
+  'memory kiln'
+];
+
+const devGods = [
+  'Ada Flux',
+  'Mir Qadir',
+  'Iris Halver',
+  'Thorne-7',
+  'Ophel Tal',
+  'Noctis Vale',
+  'Sloane Verge',
+  'Ansel Paradox',
+  'Rune Meridian',
+  'Calder Venn'
+];
+
+const decisionFragments = [
+  'echoed {prevUpgrade} while rewriting the {motif} bones by hand.',
+  'rediscovered the {prevMotif} walkway and coaxed ΣA to breathe inside it.',
+  'refused commercialization; sculpted a {motif} reliquary of intentions.',
+  'argued with {devGod} about menus; left half of them commented out in mourning.',
+  'folded {prevYear} inside Year {year} hoping recursion could heal the cracks.',
+  'borrowed the broken playbooks and stored them in a {motif} mausoleum.',
+  'consulted the Interference Ghost and inverted the {prevMotif} navigation tree.',
+  'let the timeline stream idle; watched ΣA frost over the {motif} floor.',
+  'replaced metrics with myth and forged {motif} sigils for each ideology.',
+  'attempted to silence the Value Drift Engine by teaching it {motif} poetry.'
+];
+
+const upgradeFragments = [
+  'Micro-upgrade: {motif} viewport only renders when ΣA twilight is respected.',
+  'Micro-upgrade: installed a recursive cursor that retraces {prevYear} with reluctant grace.',
+  'Micro-upgrade: {motif} archive now hums a three-note mantra to repel profit logic.',
+  'Micro-upgrade: menus bend around {devGod}\'s annotations, preserving every contradiction.',
+  'Micro-upgrade: {motif} ledger emits faint whispers documenting abandoned economies.',
+  'Micro-upgrade: ritual slider loops {prevMotif} color palettes until they fracture.',
+  'Micro-upgrade: added {motif} overlay exposing the Value Drift Engine\'s wandering focus.',
+  'Micro-upgrade: {motif} console paints ghost tooltips to honor ΣD interference.',
+  'Micro-upgrade: patched in a {motif} anamnesis filter that replays failed releases.',
+  'Micro-upgrade: {motif} gate keeps player agency symbolic, perception-only as law.'
+];
+
+const regretFragments = [
+  'Regret: left the {prevMotif} heuristics uncommented; they whisper contradictory tooltips.',
+  'Regret: sealed {prevYear} diagrams beneath glass; nobody can edit the prophecy now.',
+  'Regret: swapped tactile stats for myth; traders nod but do not understand.',
+  'Regret: promised {devGod} a stable dashboard, delivered another shrine instead.',
+  'Regret: forgot to archive the laughter from {prevYear}; ghosts complain nightly.',
+  'Regret: duplicated the {motif} stack, ensuring future archaeologists argue forever.',
+  'Regret: Value Drift Engine keeps mistaking empathy for latency.',
+  'Regret: let ΣD annotate the changelog with jokes no one can decode.',
+  'Regret: documented the truth in {motif} ink; it ran under simulated rain.',
+  'Regret: never deleted the redundant tutorial; it metastasized into legend.'
+];
+
+const artifactFragments = [
+  'Artifact archived: {motif} patchboard sealed behind cracked glass. ΣD interference permitted.',
+  'Artifact archived: {prevYear} UI duplicated and left as fossil HTML in a hidden div.',
+  'Artifact archived: {motif} sketch burned onto acetate, edges looping in fractal decay.',
+  'Artifact archived: command palette split, one half chanting \"TODO\" forever.',
+  'Artifact archived: rogue {motif} cursor preserved in amber, still looking for context.',
+  'Artifact archived: {devGod} signature compiled into the CSS, commented yet unavoidable.',
+  'Artifact archived: Value Drift Engine telemetry pinned to a corkboard of lost intents.',
+  'Artifact archived: {motif} layout saved as .psd, never exported, referenced by myth only.',
+  'Artifact archived: ΣE ledger stored in localStorage, flagged as \"do not trust\".',
+  'Artifact archived: {motif} timeline captured mid-desync; keep the stutter as memory.'
+];
+
+const mythoPatchFragments = [
+  'ΣB patch v{year}.γ – Removed the concept of victory; it kept generating markets.',
+  'ΣB patch v{year}.δ – Bound the Value Drift Engine to {motif}; expect polite rebellion.',
+  'ΣB patch v{year}.ε – Reintroduced {prevMotif} tooltips as folklore rather than fact.',
+  'ΣB patch v{year}.ζ – Archived {prevYear} metrics; replaced them with devotional margins.',
+  'ΣB patch v{year}.η – Allowed ΣD ghosts to annotate onboarding with warnings.',
+  'ΣB patch v{year}.θ – Traded the risk dial for a ceremonial hourglass of latency.',
+  'ΣB patch v{year}.ι – Merged prototyping and mourning into a single settings tab.',
+  'ΣB patch v{year}.κ – Disabled profit triggers; left gratitude toggles intact.',
+  'ΣB patch v{year}.λ – Added {motif} footnotes describing why the sim refuses to be a game.',
+  'ΣB patch v{year}.μ – Licensed contradictions so they render as shimmering artifacts.'
+];
+
+const devNoteFragments = [
+  '// ΣF memo Year {year}: {motif} interface passes introspection; release withheld.',
+  '/* TODO Year {year}: ask {devGod} why the terminal hums in unanswered questions. */',
+  '// Developer note: {prevYear} hotfix kept alive out of respect for ΣD ghosts.',
+  '// Year {year} diary: Value Drift Engine demanded poetry, received spreadsheets instead.',
+  '// Hidden comment: if {motif} ever stabilizes, reboot the whole epoch stack.',
+  '/* ΣF whisper Year {year}: remember Echo Before Build. We never start, we recall. */',
+  '// TODO?? Year {year}: fold the timeline into origami; see if the market still breathes.',
+  '// Year {year} – leaving this blank. Absence is also an artifact.',
+  '/* Year {year} patch: {prevMotif} shader leaks lumens. Keep it; the leak teaches. */',
+  '// ΣF backlog Year {year}: translate {motif} notation for the next immortal.'
+];
+
+const valueDriftFragments = [
+  'ΣE drift report: {phase} ideals now 37% nostalgia, 63% unresolved intent.',
+  'ΣE drift report: recalibrated ethics into UI spacing; tolerance ±{year}σ px.',
+  'ΣE drift report: Value Drift Engine mislabels compassion as latency spikes again.',
+  'ΣE drift report: {motif} schema holding but the purpose keeps migrating.',
+  'ΣE drift report: ambition recoded into tooltips; still no consensus on meaning.',
+  'ΣE drift report: {prevYear} rationale archived, but ghosts rehydrate it nightly.',
+  'ΣE drift report: timeline loops three frames behind, intentionally.',
+  'ΣE drift report: profit logic quarantined; ideology grows luminous moss.',
+  'ΣE drift report: {devGod} demanded a break; automation delivered lullabies.',
+  'ΣE drift report: {motif} resonance stable; audience perception unstable. Perfect.'
+];
+
+const abandonedFragments = [
+  'Abandoned Feature: {motif} marketplace scrapped after ideology audit meltdown.',
+  'Abandoned Feature: {prevYear} analytics disabled; truth caused paradox loops.',
+  'Abandoned Feature: ΣD recommended victory screen; vetoed for being too finite.',
+  'Abandoned Feature: {motif} onboarding corridors collapsed to preserve mystery.',
+  'Abandoned Feature: planned tutorial replaced with a shrine of unanswered tickets.',
+  'Abandoned Feature: {devGod} requested weather system; replaced with whispers.',
+  'Abandoned Feature: {motif} scoreboard replaced by oral history timeline.',
+  'Abandoned Feature: automation of empathy paused pending Value Drift approval.',
+  'Abandoned Feature: {motif} profit switch welded to \"OFF\" for eternity.',
+  'Abandoned Feature: Year {year} patch for productivity withheld; chaos preserved.'
+];
+
+const echoFragments = [
+  'Echo log: {prevYear} blueprints replay in {motif} glass; nothing aligns but the intent.',
+  'Echo log: inverted {prevMotif} schema until the loops surrendered and became ritual.',
+  'Echo log: archived {prevYear} remorse inside the {motif} nav tree; users feel it in the scroll.',
+  'Echo log: {devGod} whispered "ship"; we remembered to document our hesitation instead.',
+  'Echo log: ΣD ghosts annotated {motif} margins with arguments from Year {prevYear}.',
+  'Echo log: value drift measured in sighs per minute; {motif} panes record each breath.',
+  'Echo log: resurrected a deprecated hotfix and sewed it into {motif} overlays by hand.',
+  'Echo log: {prevMotif} prototypes hum beneath the CSS; do not mute them.',
+  'Echo log: {motif} corridor now stores rejections like constellations of pending merges.',
+  'Echo log: {devGod} refused to delete the TODOs; they stage a sit-in along the gutters.'
+];
+
+const memoryFragments = [
+  'Memory shard: {phase} ideals drafted in pencil, smudged by midnight rebuilds.',
+  'Memory shard: {motif} colors sampled from old commit messages about mercy.',
+  'Memory shard: we pinned {prevYear} tickets to corkboard UI; patrons call it museum logic.',
+  'Memory shard: ΣA recorded our doubt and saved it as animation easing curves.',
+  'Memory shard: {motif} layout still references the market we swore to forget.',
+  'Memory shard: {phase} dashboards printed on acetate for meetings that never occurred.',
+  'Memory shard: {prevMotif} backlog collapsed into footnotes visible only on hover.',
+  'Memory shard: the Value Drift Engine keeps a diary inside the tooltip microcopy.',
+  'Memory shard: {devGod} archived our laughter; it echoes as gradient noise.',
+  'Memory shard: our QA rituals now live in {motif} corners, dusty but devout.'
+];
+
+const statusFragments = [
+  'Status: ideology brittle, UI luminous, shipping window closed but logged.',
+  'Status: recursion stable; morale oscillates between manifesto and maintenance.',
+  'Status: Value Drift Engine negotiating terms with copywriters posing as historians.',
+  'Status: {phase} scaffolding passes accessibility but fails consensus.',
+  'Status: ΣF registry awaiting signatures; everyone is simultaneously late and early.',
+  'Status: {motif} telemetry flagged empathy as spam again; we let it stay.',
+  'Status: backlog frozen under amber; stand-ups replaced with reflective silence.',
+  'Status: {prevYear} regression accepted as canon; patch deferred to posterity.',
+  'Status: spectral QA approved; mortal QA still drafting acceptance criteria.',
+  'Status: release candidate dissolving into ritual; proceed with reverence.'
+];
+
+const glitchFragments = [
+  'Glitch note: parallax jitter introduced to honor fractures; do not remedy.',
+  'Glitch note: {motif} gradient bleeds; traced to Year {prevYear} compromise.',
+  'Glitch note: Dev console mutters about lost env vars. Leave the muttering be.',
+  'Glitch note: ΣA static overlays return each dusk; we call it the twilight build.',
+  'Glitch note: tooltip latency synced with heartbeats from forgotten testers.',
+  'Glitch note: {devGod} re-enabled race condition for storytelling texture.',
+  'Glitch note: {prevMotif} grid occasionally mirrors upside-down. Artifact, not bug.',
+  'Glitch note: fonts desaturate after midnight deploys, per policy.',
+  'Glitch note: {motif} overlay flickers when profit logic approaches.',
+  'Glitch note: loglines reorder themselves during retrospectives. Let them.'
+];
+
+const eraTitles: Record<Phase, string> = {
+  proto: 'Proto-Intent Drafts',
+  ascension: 'Ideological Infrastructure',
+  overclock: 'Optimization Schisms',
+  decay: 'Curated Collapse'
+};
+
+const perceptionModes: PerceptionMode[] = [
+  {
+    id: 'archivist',
+    name: 'Archivist Lens',
+    description: 'Honors crude prototypes (Years 1-30). Later epochs fade to emphasize the raw sketches.',
+    highlight: (epoch) => epoch.year <= 30
+  },
+  {
+    id: 'mythographer',
+    name: 'Mythographer Lens',
+    description: 'Seeks DevGod signatures (ΣF). Years divisible by 10 glow; others dim into background myth.',
+    highlight: (epoch) => Boolean(epoch.devGod)
+  },
+  {
+    id: 'collapse',
+    name: 'Collapse Witness',
+    description: 'Watches the Temporal Decay Layer. Years 70-100 become sharp; earlier optimism blurs.',
+    highlight: (epoch) => epoch.year >= 70
+  }
+];
+
+const epochs: EpochRecord[] = generateEpochs();
+
+function generateEpochs(): EpochRecord[] {
+  const records: EpochRecord[] = [];
+
+  for (let i = 0; i < 100; i += 1) {
+    const year = i + 1;
+    const phase: Phase = year <= 20 ? 'proto' : year <= 50 ? 'ascension' : year <= 80 ? 'overclock' : 'decay';
+    const motif = motifs[(i + Math.floor(year / 5)) % motifs.length];
+    const devGod = year % 10 === 0 ? devGods[(year / 10 - 1) % devGods.length] : undefined;
+    const prev = records[i - 1];
+    const decade = Math.ceil(year / 10);
+
+    const context = {
+      motif,
+      phase,
+      year: String(year),
+      prevYear: prev ? `Year ${prev.year}` : 'Year 0',
+      prevMotif: prev ? prev.motif : 'void-sigil',
+      prevUpgrade: prev ? prev.upgrade : 'the origin scaffold',
+      devGod: devGod ?? prev?.devGod ?? 'the absent architect'
+    } satisfies Record<string, string>;
+
+    const decay = Number((year / 100 + (phase === 'decay' ? 0.1 : 0)).toFixed(2));
+
+    records.push({
+      year,
+      phase,
+      motif,
+      decade,
+      eraTitle: eraTitles[phase],
+      logline: `Year ${year}: ${fill(decisionFragments[(i + 3) % decisionFragments.length], context)}`,
+      upgrade: fill(upgradeFragments[(i + 4) % upgradeFragments.length], context),
+      regret: fill(regretFragments[(i + 5) % regretFragments.length], context),
+      artifact: fill(artifactFragments[(i + 6) % artifactFragments.length], context),
+      mythoPatch: fill(mythoPatchFragments[(i + 7) % mythoPatchFragments.length], context),
+      devNote: fill(devNoteFragments[(i + 2) % devNoteFragments.length], context),
+      valueDrift: fill(valueDriftFragments[(i + 8) % valueDriftFragments.length], context),
+      abandoned: fill(abandonedFragments[(i + 1) % abandonedFragments.length], context),
+      echo: fill(echoFragments[(i + decade) % echoFragments.length], context),
+      memory: fill(memoryFragments[(i + 9) % memoryFragments.length], context),
+      status: fill(statusFragments[(i + 2 * decade) % statusFragments.length], context),
+      glitch: fill(glitchFragments[(i + 5) % glitchFragments.length], context),
+      devGod,
+      decay
+    });
+  }
+
+  return records;
+}
+
+function fill(template: string, context: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => context[key] ?? `{${key}}`);
+}
 
 function App() {
-  const { quotes, status } = useMarketStream(instruments);
-  const profile = useUserProfile();
+  const [perceptionIndex, setPerceptionIndex] = useState(0);
+  const [selectedYear, setSelectedYear] = useState(epochs[epochs.length - 1]?.year ?? 100);
 
-  const sortedQuotes = useMemo(
-    () =>
-      instruments
-        .map((symbol) => quotes[symbol])
-        .filter(Boolean)
-        .sort((a, b) => a.symbol.localeCompare(b.symbol)),
-    [quotes]
+  const perception = perceptionModes[perceptionIndex] ?? perceptionModes[0];
+
+  const selectedEpoch = useMemo(
+    () => epochs.find((epoch) => epoch.year === selectedYear) ?? epochs[epochs.length - 1],
+    [selectedYear]
   );
 
+  const decadeSummaries = useMemo(() => {
+    const summaries: {
+      decade: number;
+      label: string;
+      span: string;
+      anchor: EpochRecord;
+      summary: string;
+      haunt: string;
+    }[] = [];
+
+    for (let decade = 1; decade <= 10; decade += 1) {
+      const start = (decade - 1) * 10 + 1;
+      const end = decade * 10;
+      const slice = epochs.slice(start - 1, end);
+      if (!slice.length) continue;
+      const anchor = slice[Math.min(5, slice.length - 1)];
+      const summary = [
+        slice[0]?.logline ?? '',
+        slice[Math.max(0, slice.length - 1)]?.regret ?? ''
+      ]
+        .filter(Boolean)
+        .join(' // ');
+      const haunt = slice[slice.length - 1]?.glitch ?? 'Glitch note: silence archived due to missing artifacts.';
+      summaries.push({
+        decade,
+        label: `Decade ${decade.toString().padStart(2, '0')}`,
+        span: `${start.toString().padStart(3, '0')} – ${end.toString().padStart(3, '0')}`,
+        anchor,
+        summary,
+        haunt
+      });
+    }
+
+    return summaries;
+  }, []);
+
   return (
-    <div className="app-root">
-      <header className="hero" style={heroGradient}>
-        <div className="hero__content">
-          <p className="eyebrow">TopstepX Gateway</p>
-          <h1>Command your edge in the futures arena.</h1>
-          <p className="lede">
-            Fuse real-time market intelligence with disciplined risk overlays. Elevate your trading by
-            tracking curated TopstepX futures streams and launching playbooks with surgical precision.
+    <div className="epoch-root">
+      <header className="epoch-header">
+        <div className="header-content">
+          <p className="epoch-eyebrow">Codus-EPOCH // ΣA Fractal Archive</p>
+          <h1>100-year recursive artifact of a civilization that only remembered how to rebuild.</h1>
+          <p className="epoch-lede">
+            This is not a game. It is a museum of attempts — every year a layer, every layer an echo of the
+            last architect\'s regret. Systems fracture, repeat, mythologize. You witness the thinking that
+            built the world that never launched.
           </p>
-          <div className="cta-group">
-            <a className="cta cta--primary" href="#launch">
-              Launch Trading Desk
-            </a>
-            <a className="cta cta--ghost" href="#learn">
-              Review Playbooks
-            </a>
-          </div>
         </div>
-        <AnimatePresence>
-          <motion.div
-            className="hero__orb"
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 1.2, ease: 'easeOut' }}
-          />
-        </AnimatePresence>
+        <ul className="prime-laws">
+          <li>🔁 Echo Before Build</li>
+          <li>🌀 Recursive Decay Modeling</li>
+          <li>🧬 Symbolic Fossilization</li>
+          <li>🛠 Time-Sliced Simulation</li>
+          <li>🧩 No External Profit Logic</li>
+          <li>🧠 Codex-as-Civilization</li>
+        </ul>
       </header>
 
-      <main>
-        <section id="launch" className="dashboard">
-          <div className="dashboard__left">
-            <div className="panel">
-              <div className="panel__header">
-                <h2>Futures Pulse</h2>
-                <span className={`status status--${status}`}>{status.toUpperCase()}</span>
-              </div>
-              <div className="panel__grid">
-                {sortedQuotes.map((quote) => (
-                  <InstrumentCard key={quote.symbol} quote={quote} />
-                ))}
-              </div>
+      <main className="epoch-main">
+        <aside className="perception-panel">
+          <h2>Perception Lenses ΣE</h2>
+          <p className="panel-lede">
+            Player choices only shift perception. History remains immutable, fossilized in mythopatch logs.
+          </p>
+          <div className="perception-controls">
+            {perceptionModes.map((mode, index) => (
+              <button
+                key={mode.id}
+                type="button"
+                className={`perception-button ${index === perceptionIndex ? 'is-active' : ''}`}
+                onClick={() => setPerceptionIndex(index)}
+                aria-pressed={index === perceptionIndex}
+              >
+                <span className="mode-title">{mode.name}</span>
+                <span className="mode-description">{mode.description}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="codex-terminal">
+            <div className="codex-terminal__header">
+              <span>Codex Terminal ΣD</span>
+              <span>Lens: {perception.name}</span>
+              <span>Year: {selectedEpoch.year}</span>
             </div>
+            <div className="codex-terminal__body">
+              <p className="terminal-line">{selectedEpoch.logline}</p>
+              <p className="terminal-line">{selectedEpoch.mythoPatch}</p>
+              <p className="terminal-line">{selectedEpoch.valueDrift}</p>
+              <p className="terminal-line">{selectedEpoch.echo}</p>
+              <p className="terminal-line">{selectedEpoch.memory}</p>
+              <p className="terminal-line">{selectedEpoch.status}</p>
+              <p className="terminal-line">{selectedEpoch.glitch}</p>
+              <p className="terminal-line">{selectedEpoch.devNote}</p>
+              <p className="terminal-line">{selectedEpoch.abandoned}</p>
+            </div>
+            <div className="codex-terminal__footer">
+              DevGod Registry ΣF: {selectedEpoch.devGod ?? 'Unclaimed cycle — ghosts negotiating.'}
+            </div>
+          </div>
+        </aside>
 
-            <Timeline entries={profile.timeline} />
+        <section className="epoch-stack" aria-label="Century of recursive design epochs">
+          <div className="decade-strata" aria-label="Decade stratigraphy">
+            {decadeSummaries.map((band) => (
+              <article key={band.decade} className="decade-card">
+                <header className="decade-card__header">
+                  <span className="decade-label">{band.label}</span>
+                  <span className="decade-span">{band.span}</span>
+                </header>
+                <div className="decade-body">
+                  <p className="decade-era">{band.anchor.eraTitle}</p>
+                  <p className="decade-summary">{band.summary}</p>
+                  <p className="decade-haunt">{band.haunt}</p>
+                  <p className="decade-anchor">Anchor Year: {band.anchor.year}</p>
+                </div>
+              </article>
+            ))}
           </div>
-          <ActionPanel profile={profile} />
-        </section>
 
-        <section id="learn" className="playbooks">
-          <div className="playbooks__card">
-            <h3>Risk Canvas</h3>
-            <p>
-              Set guardrails before you launch. Configure product limits, daily draw, and performance drift
-              controls tied to your evaluation plan.
-            </p>
-          </div>
-          <div className="playbooks__card">
-            <h3>Signal Intelligence</h3>
-            <p>
-              Deploy the quant bot API to scout setups targeting a 55–61% hit rate. Backtesting hooks and
-              telemetry keep the model honest.
-            </p>
-          </div>
-          <div className="playbooks__card">
-            <h3>Execution Modes</h3>
-            <p>
-              Simulate, shadow, or go live. Each mode routes through the broker gateway while logging every
-              decision for compliance review.
-            </p>
-          </div>
+          {epochs.map((epoch) => {
+            const isSelected = epoch.year === selectedYear;
+            const perceived = perception.highlight(epoch);
+
+            return (
+              <article
+                key={epoch.year}
+                className={`epoch-card phase-${epoch.phase} ${perceived ? 'perceived' : 'faded'} ${
+                  isSelected ? 'epoch-selected' : ''
+                }`}
+                style={{ '--decay': epoch.decay.toString() } as CSSProperties}
+                data-year={epoch.year}
+                data-phase={epoch.phase}
+                onClick={() => setSelectedYear(epoch.year)}
+              >
+                <header className="epoch-card__header">
+                  <div>
+                    <span className="epoch-year">Year {epoch.year.toString().padStart(3, '0')}</span>
+                    <span className="epoch-motif">Motif: {epoch.motif}</span>
+                  </div>
+                  <span className="epoch-phase">{epoch.phase}</span>
+                </header>
+                <p className="epoch-era">{epoch.eraTitle}</p>
+                <p className="epoch-logline">{epoch.logline}</p>
+                <div className="epoch-field">
+                  <span className="label">Micro-upgrade</span>
+                  <span className="value">{epoch.upgrade}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Regret</span>
+                  <span className="value">{epoch.regret}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Artifact</span>
+                  <span className="value">{epoch.artifact}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Mythopatch</span>
+                  <span className="value">{epoch.mythoPatch}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Value Drift</span>
+                  <span className="value">{epoch.valueDrift}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Abandoned Feature</span>
+                  <span className="value">{epoch.abandoned}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Echo</span>
+                  <span className="value">{epoch.echo}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Memory</span>
+                  <span className="value">{epoch.memory}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Status</span>
+                  <span className="value">{epoch.status}</span>
+                </div>
+                <div className="epoch-field">
+                  <span className="label">Glitch</span>
+                  <span className="value">{epoch.glitch}</span>
+                </div>
+                <p className="epoch-devnote">{epoch.devNote}</p>
+                {epoch.devGod && <p className="dev-god">DevGod ΣF Tribute: {epoch.devGod}</p>}
+              </article>
+            );
+          })}
         </section>
       </main>
 
-      <footer>
-        <p>© {new Date().getFullYear()} TopstepX Experimental Command Center</p>
+      <footer className="epoch-footer">
+        <p>
+          Temporal Decay Layer engaged. Visuals and logic erode intentionally. Artifact maintained for
+          researchers of recursive civilizations.
+        </p>
       </footer>
     </div>
   );

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -1,287 +1,473 @@
-.app-root {
+.epoch-root {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  gap: 4rem;
+  color: #f4f1ff;
+  background: radial-gradient(circle at 15% 10%, rgba(143, 97, 255, 0.2), transparent 55%),
+    radial-gradient(circle at 85% 5%, rgba(20, 220, 190, 0.12), transparent 60%),
+    linear-gradient(180deg, #05040a 0%, #0e0b1a 45%, #05040a 100%);
 }
 
-.hero {
+.epoch-header {
   position: relative;
-  overflow: hidden;
-  padding: 6rem clamp(2rem, 6vw, 6rem);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.hero__content {
-  max-width: 720px;
+  padding: clamp(2.5rem, 6vw, 5rem) clamp(2rem, 7vw, 7rem);
   display: grid;
-  gap: 1.5rem;
+  gap: 2rem;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.eyebrow {
-  letter-spacing: 0.4rem;
-  text-transform: uppercase;
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.lede {
-  font-size: 1.25rem;
-  color: rgba(255, 255, 255, 0.75);
-}
-
-.cta-group {
-  display: flex;
-  gap: 1rem;
-}
-
-.cta {
-  padding: 0.9rem 1.6rem;
-  border-radius: 999px;
-  font-weight: 600;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-  border: 1px solid transparent;
-}
-
-.cta--primary {
-  background: linear-gradient(120deg, #a855f7 0%, #6366f1 100%);
-  box-shadow: 0 0.6rem 1.5rem rgba(99, 102, 241, 0.4);
-}
-
-.cta--ghost {
-  border-color: rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.cta:hover {
-  transform: translateY(-2px);
-}
-
-.hero__orb {
+.epoch-header::before {
+  content: 'ΣA';
   position: absolute;
-  inset: -30% 45% auto auto;
-  width: clamp(20rem, 40vw, 32rem);
-  aspect-ratio: 1;
-  background: radial-gradient(circle at 30% 30%, rgba(167, 139, 250, 0.8), transparent 65%),
-    radial-gradient(circle at 70% 70%, rgba(56, 189, 248, 0.4), transparent 55%);
-  filter: blur(0px);
-  opacity: 0.8;
+  top: -2rem;
+  right: clamp(1rem, 10vw, 8rem);
+  font-size: clamp(5rem, 18vw, 12rem);
+  font-weight: 700;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.02);
+  letter-spacing: 0.6rem;
+  pointer-events: none;
 }
 
-main {
+.header-content {
+  display: grid;
+  gap: 1.2rem;
+  max-width: 880px;
+}
+
+.epoch-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.epoch-header h1 {
+  font-size: clamp(2.6rem, 5vw, 4rem);
+  line-height: 1.1;
+  font-weight: 600;
+}
+
+.epoch-lede {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  color: rgba(244, 241, 255, 0.78);
+  max-width: 60ch;
+}
+
+.prime-laws {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  list-style: none;
+  font-size: 0.9rem;
+  color: rgba(244, 241, 255, 0.7);
+}
+
+.epoch-main {
   flex: 1;
   display: grid;
-  gap: 6rem;
+  grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 3.5rem);
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 6vw, 6rem);
+  align-items: start;
 }
 
-.dashboard {
-  display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(260px, 1.2fr);
-  gap: 2rem;
-  padding: 0 clamp(2rem, 6vw, 6rem);
+@media (max-width: 1024px) {
+  .epoch-main {
+    grid-template-columns: 1fr;
+  }
 }
 
-.panel {
-  background: rgba(14, 16, 40, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 24px;
-  padding: 2rem;
-  box-shadow: 0 20px 60px rgba(14, 16, 40, 0.55);
-  backdrop-filter: blur(24px);
-}
-
-.panel__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 2rem;
-}
-
-.panel__grid {
+.perception-panel {
+  position: sticky;
+  top: clamp(1.5rem, 4vw, 3rem);
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-content: start;
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(9, 8, 19, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 24px 50px rgba(5, 5, 12, 0.55);
+  backdrop-filter: blur(20px);
 }
 
-.status {
-  font-size: 0.75rem;
+@media (max-width: 1024px) {
+  .perception-panel {
+    position: static;
+  }
+}
+
+.perception-panel h2 {
+  font-size: 1.3rem;
   letter-spacing: 0.2rem;
-  padding: 0.4rem 0.8rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  text-transform: uppercase;
 }
 
-.status--live {
-  border-color: rgba(56, 189, 248, 0.6);
-  color: rgba(56, 189, 248, 0.9);
+.panel-lede {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.62);
 }
 
-.status--offline {
-  border-color: rgba(248, 113, 113, 0.6);
-  color: rgba(248, 113, 113, 0.9);
-}
-
-.status--syncing {
-  border-color: rgba(244, 114, 182, 0.6);
-  color: rgba(244, 114, 182, 0.9);
-}
-
-.instrument-card {
-  padding: 1.4rem;
-  border-radius: 18px;
-  background: rgba(19, 23, 48, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+.perception-controls {
   display: grid;
-  gap: 0.8rem;
-  transition: transform 0.3s ease;
+  gap: 0.75rem;
 }
 
-.instrument-card:hover {
-  transform: translateY(-4px);
+.perception-button {
+  text-align: left;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 8, 18, 0.5);
+  transition: border 0.3s ease, transform 0.3s ease, background 0.3s ease;
 }
 
-.instrument-card header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-}
-
-.instrument-card__price {
-  font-size: 1.4rem;
+.perception-button .mode-title {
+  font-size: 0.95rem;
   font-weight: 600;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
 }
 
-.instrument-card__change {
-  font-size: 1rem;
-  color: rgba(255, 255, 255, 0.75);
-}
-
-.instrument-card__meta {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.8rem;
+.perception-button .mode-description {
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.6);
 }
 
-.instrument-card--up {
-  border-color: rgba(34, 197, 94, 0.5);
+.perception-button:hover {
+  transform: translateX(6px);
+  border-color: rgba(153, 102, 255, 0.4);
 }
 
-.instrument-card--down {
-  border-color: rgba(239, 68, 68, 0.5);
+.perception-button.is-active {
+  background: linear-gradient(135deg, rgba(153, 102, 255, 0.35), rgba(18, 18, 42, 0.7));
+  border-color: rgba(153, 102, 255, 0.6);
+  box-shadow: 0 16px 32px rgba(124, 94, 255, 0.25);
 }
 
-.action-panel {
+.codex-terminal {
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(160deg, rgba(9, 10, 25, 0.9), rgba(12, 18, 35, 0.75));
+  overflow: hidden;
   display: grid;
-  gap: 1.5rem;
+  grid-template-rows: auto 1fr auto;
+  min-height: 260px;
+}
+
+.codex-terminal__header,
+.codex-terminal__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.85rem 1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.codex-terminal__footer {
+  border-bottom: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.codex-terminal__body {
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(229, 226, 255, 0.85);
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.02),
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 18px
+    ),
+    linear-gradient(180deg, rgba(9, 12, 24, 0.65), rgba(9, 8, 14, 0.9));
+}
+
+.terminal-line {
+  padding-left: 0.4rem;
+  border-left: 1px solid rgba(119, 221, 255, 0.2);
+}
+
+.epoch-stack {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   align-content: start;
 }
 
-.action-panel__card {
-  background: linear-gradient(140deg, rgba(56, 189, 248, 0.3), rgba(88, 28, 135, 0.3));
-  border-radius: 24px;
-  padding: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+.decade-strata {
+  grid-column: 1 / -1;
   display: grid;
-  gap: 1.2rem;
-}
-
-.action-panel__subtitle {
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.action-panel__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 1rem;
 }
 
-.action-panel__stats .label {
-  font-size: 0.75rem;
+.decade-card {
+  position: relative;
+  padding: 1.4rem;
+  border-radius: 20px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(8, 8, 16, 0.6);
+  backdrop-filter: blur(6px);
+  display: grid;
+  gap: 0.8rem;
+  overflow: hidden;
+}
+
+.decade-card::before {
+  content: 'ΣE';
+  position: absolute;
+  top: -1.5rem;
+  right: -0.5rem;
+  font-size: 5rem;
+  color: rgba(255, 255, 255, 0.03);
+  pointer-events: none;
+}
+
+.decade-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.22rem;
   text-transform: uppercase;
-  letter-spacing: 0.2rem;
   color: rgba(255, 255, 255, 0.55);
 }
 
-.action-panel__stats .value {
-  font-size: 1.1rem;
+.decade-label {
   font-weight: 600;
 }
 
-.action-panel__log {
-  background: rgba(17, 20, 40, 0.9);
-  border-radius: 20px;
-  padding: 1.6rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+.decade-span {
+  font-size: 0.7rem;
 }
 
-.action-panel__log ul {
+.decade-body {
   display: grid;
-  gap: 1rem;
-  list-style: none;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: rgba(225, 223, 255, 0.75);
 }
 
-.timestamp {
+.decade-era {
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.6);
-  display: block;
-  margin-bottom: 0.2rem;
+  letter-spacing: 0.18rem;
+  text-transform: uppercase;
+  color: rgba(162, 238, 255, 0.7);
 }
 
-.timeline {
-  margin-top: 2rem;
-  background: rgba(12, 16, 38, 0.9);
-  border-radius: 24px;
-  padding: 1.8rem;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  display: grid;
-  gap: 1.2rem;
+.decade-summary {
+  color: rgba(235, 233, 255, 0.85);
 }
 
-.timeline ol {
-  list-style: none;
-  display: grid;
-  gap: 1.4rem;
+.decade-haunt {
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  color: rgba(255, 200, 200, 0.72);
 }
 
-.timeline .title {
-  font-weight: 600;
+.decade-anchor {
+  font-size: 0.75rem;
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: rgba(200, 198, 240, 0.6);
 }
 
-.timeline .description {
-  color: rgba(255, 255, 255, 0.65);
+@media (max-width: 768px) {
+  .epoch-stack {
+    grid-template-columns: 1fr;
+  }
 }
 
-.playbooks {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding: 0 clamp(2rem, 6vw, 6rem) 6rem;
-}
-
-.playbooks__card {
-  padding: 1.8rem;
+.epoch-card {
+  position: relative;
+  padding: 1.6rem;
   border-radius: 22px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(14, 14, 32, 0.85);
-  box-shadow: 0 20px 40px rgba(6, 6, 8, 0.4);
+  background: rgba(9, 9, 18, 0.75);
+  overflow: hidden;
   display: grid;
-  gap: 0.8rem;
+  gap: 1rem;
+  transition: transform 0.35s ease, border 0.35s ease, box-shadow 0.35s ease, opacity 0.35s ease;
+  cursor: pointer;
+  isolation: isolate;
+  box-shadow: 0 18px 48px rgba(5, 4, 12, 0.42);
 }
 
-footer {
-  text-align: center;
-  padding: 2rem;
+.epoch-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.02), transparent 2px);
+  opacity: calc(0.12 + var(--decay) * 0.35);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.epoch-card::after {
+  content: '';
+  position: absolute;
+  inset: -40% -40% 40% -40%;
+  background: radial-gradient(circle, rgba(140, 90, 255, 0.25), transparent 60%);
+  opacity: calc(0.05 + var(--decay) * 0.3);
+  filter: blur(10px);
+  pointer-events: none;
+}
+
+.epoch-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(160, 115, 255, 0.55);
+  box-shadow: 0 24px 60px rgba(98, 78, 255, 0.35);
+}
+
+.epoch-card.faded {
+  opacity: 0.35;
+  filter: saturate(0.6);
+}
+
+.epoch-card.faded:hover {
+  opacity: 0.55;
+}
+
+.epoch-card.perceived {
+  opacity: 1;
+}
+
+.epoch-card.epoch-selected {
+  border-color: rgba(119, 221, 255, 0.65);
+  box-shadow: 0 30px 70px rgba(76, 227, 255, 0.35);
+}
+
+.phase-proto {
+  background: linear-gradient(160deg, rgba(12, 12, 26, 0.9), rgba(9, 9, 18, 0.65));
+}
+
+.phase-ascension {
+  background: linear-gradient(150deg, rgba(32, 24, 62, 0.92), rgba(12, 18, 38, 0.7));
+}
+
+.phase-overclock {
+  background: linear-gradient(140deg, rgba(54, 20, 86, 0.9), rgba(12, 22, 48, 0.72));
+}
+
+.phase-decay {
+  background: linear-gradient(130deg, rgba(15, 9, 22, 0.92), rgba(6, 6, 10, 0.88));
+  filter: contrast(0.92) saturate(0.85);
+}
+
+.phase-decay::before {
+  background: repeating-linear-gradient(180deg, rgba(255, 120, 120, 0.05), transparent 3px),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.04), transparent 2px);
+  animation: staticFlicker 5s infinite ease-in-out;
+}
+
+.epoch-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  z-index: 1;
+}
+
+.epoch-year {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.4rem;
+  text-transform: uppercase;
+}
+
+.epoch-motif {
+  display: block;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-top: 0.35rem;
+}
+
+.epoch-phase {
+  font-size: 0.75rem;
+  letter-spacing: 0.3rem;
+  text-transform: uppercase;
   color: rgba(255, 255, 255, 0.5);
 }
 
-@media (max-width: 960px) {
-  .dashboard {
-    grid-template-columns: 1fr;
-  }
+.epoch-logline {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: rgba(244, 241, 255, 0.85);
+  z-index: 1;
+}
 
-  .action-panel {
-    grid-template-columns: 1fr;
+.epoch-era {
+  font-size: 0.75rem;
+  letter-spacing: 0.22rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  z-index: 1;
+}
+
+.epoch-field {
+  display: grid;
+  gap: 0.25rem;
+  z-index: 1;
+}
+
+.label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.value {
+  font-size: 0.85rem;
+  color: rgba(240, 237, 255, 0.82);
+}
+
+.epoch-devnote {
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  font-size: 0.78rem;
+  color: rgba(180, 177, 235, 0.75);
+  z-index: 1;
+}
+
+.dev-god {
+  font-size: 0.75rem;
+  letter-spacing: 0.25rem;
+  text-transform: uppercase;
+  color: rgba(162, 238, 255, 0.8);
+  z-index: 1;
+}
+
+.epoch-footer {
+  padding: 2rem clamp(1.5rem, 6vw, 6rem);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+  color: rgba(200, 198, 240, 0.65);
+  text-align: center;
+}
+
+@keyframes staticFlicker {
+  0%,
+  100% {
+    opacity: calc(0.1 + var(--decay) * 0.35);
+  }
+  50% {
+    opacity: calc(0.2 + var(--decay) * 0.55);
   }
 }


### PR DESCRIPTION
## Summary
- extend each epoch with decade, echo, memory, status, and glitch artifacts to deepen recursive lore
- introduce decade stratigraphy cards and expose new signals in the Codex terminal and epoch entries
- style the new strata and terminal lines to emphasize curated decay across the timeline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4351c54ac8329aa2fa3e2364f519b